### PR TITLE
[COOK-1623] Added new attribute install_erlang

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Cookbook attributes are named under the `couch_db` keyspace. The attributes spec
 * `node['couch_db']['src_mirror']` - full URL to download.
 * `node['couch_db']['bind_address']` - specify address couchdb should
   bind to. nil by default, which will use couchdb's built in default, 5984.
+* `node['couch_db']['install_erlang'] - specify if erlang should be installed prior to
+  couchdb, true by default.
 
 RECIPES
 =======

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,4 +20,6 @@
 set['couch_db']['src_checksum']      = "6ef82a7ba0f132d55af7cc78b30658d5b3a4f7be3f449308c8d7fa2ad473677c"
 set['couch_db']['src_version']       = "1.0.2"
 set['couch_db']['src_mirror']        = "http://archive.apache.org/dist/couchdb/#{node['couch_db']['src_version']}/apache-couchdb-#{node['couch_db']['src_version']}.tar.gz"
+
 default['couch_db']['bind_address']  = nil
+default['couch_db']['install_erlang'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe "erlang"
+if node['couch_db']['install_erlang']
+  include_recipe "erlang"
+end
 
 case node['platform']
 when "redhat","centos","fedora","amazon"

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -22,7 +22,9 @@ if node['platform'] == "ubuntu" && node['platform_version'].to_f == 8.04
   return
 end
 
-include_recipe "erlang"
+if node['couch_db']['install_erlang']
+  include_recipe "erlang"
+end
 
 couchdb_tar_gz = File.join(Chef::Config[:file_cache_path], "/", "apache-couchdb-#{node['couch_db']['src_version']}.tar.gz")
 compile_flags = String.new


### PR DESCRIPTION
Here the key points of thir PR:
- Added a new attribute `install_erlang` that can be use to switch off erlang
  installation when you want to install erlang in your own way.
- Fully BC since the default value for the attribute is `true`.

Regards,
Matt
