### PR TITLE
Fix for [COOK-1905]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,98 @@ Also works on Red Hat, CentOS and Fedora, requires the EPEL yum repository.
 ATTRIBUTES
 ==========
 
-Cookbook attributes are named under the `couch_db` keyspace. The attributes specified in the cookbook are used in the `couchdb::source` recipe only.
+Cookbook attributes are named under the `couch_db` keyspace.
 
 * `node['couch_db']['src_checksum']` - sha256sum of the default version of couchdb to download
 * `node['couch_db']['src_version']` - default version of couchdb to download, used in the full URL to download.
 * `node['couch_db']['src_mirror']` - full URL to download.
-* `node['couch_db']['bind_address']` - specify address couchdb should
-  bind to. nil by default, which will use couchdb's built in default, 5984.
-* `node['couch_db']['install_erlang'] - specify if erlang should be installed prior to
+* `node['couch_db']['install_erlang']` - specify if erlang should be installed prior to
   couchdb, true by default.
+
+Configuration
+-------------
+
+The `local.ini` file is dynamically generated from attributes. Each key in
+`node['couch_db']['config']` is a CouchDB configuration directive, and will
+be rendered in the config file. For example, the attribute:
+
+    node['couch_db']['config']['httpd']['bind_address'] = "0.0.0.0"
+
+Will result in the following lines in the `local.ini` file:
+
+    [httpd]
+    bind_address = "0.0.0.0"
+
+The attributes file contains default values for platform-independent
+parameters. All parameter values that expect a path argument are
+not set by default. The default values that are currently set have
+been taken from the CouchDB configuration
+[wiki page](http://wiki.apache.org/couchdb/Configurationfile_couch.ini).
+
+The resulting configuration file is now dynamically rendered from the
+attributes. Each subkey below the `config` key is a specific section
+of the `local.ini` file. Then each subkey in a section is a parameter
+associated with a value.
+
+You should consult the CouchDB documentation for specific
+configuration details.
+
+For values that are "on" or "off", they should be specified as literal
+`true` or `false`. Any configuration option set to the literal `nil` will
+be skipped entirely. All other values (e.g., string, numeric literals) will
+be used as is. So for example:
+
+    node.default['couch_db']['config']['couchdb']['os_process_timeout'] = 5000
+    node.default['couch_db']['config']['couchdb']['delayed_commits'] = true
+    node.default['couch_db']['config']['couchdb']['batch_save_interval'] = nil
+    node.default['couch_db']['config']['httpd']['port'] = 5984
+    node.default['couch_db']['config']['httpd']['bind_address'] = "127.0.0.1"
+
+Will result in the following config lines:
+
+    [couchdb]
+    os_process_timeout = 5000
+    delayed_commits = true
+
+    [httpd]
+    port = 5984
+    bind_address = 127.0.0.1
+
+(no line printed for `batch_save_interval` as it is `nil`)
+
+### Defaults
+
+Here the list of attributes that are already provided by the recipe
+and their associated default value.
+
+#### Section [couchdb]
+
+* `node['couch_db']['config]['couchdb']['max_document_size']` -
+   Maximum size of a document in bytes, defaults to `4294967296` (`4 GB`).
+* `node['couch_db']['config]['couchdb']['max_attachment_chunk_size']` -
+   Maximum chunk size of an attachment in bytes, defaults to `4294967296` (`4 GB`).
+* `node['couch_db']['config]['couchdb']['os_process_timeout']` -
+   OS process timeout for view and external servers in milliseconds, defaults to `5000` (`5 seconds`).
+* `node['couch_db']['config]['couchdb']['max_dbs_open']` -
+   Upper bound limit on the number of databases that can be open at one time, defaults to `100`.
+* `node['couch_db']['config]['couchdb']['delayed_commits']` -
+   Determines if commits should be delayed, defaults to `true`.
+* `node['couch_db']['config]['couchdb']['batch_save_size']` -
+   Number of document at which to save a batch, defaults to `1000`.
+* `node['couch_db']['config]['couchdb']['batch_save_interval']` -
+   Interval after which to save batches in milliseconds, default to `1000` (`1 second`).
+
+#### Section [httpd]
+
+* `node['couch_db']['config']['httpd']['port']` -
+   Port CouchDB should bind to, defaults to `5984`.
+* `node['couch_db']['config']['httpd']['bind_address']` -
+   IP address CouchDB should bind to, defaults to `127.0.0.1`.
+
+#### Section [log]
+
+* `node['couch_db']['config']['log']['level']` -
+   CouchDB's log level, defaults to `info`.
 
 RECIPES
 =======

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,8 +17,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-default['couch_db']['src_checksum']      = "6ef82a7ba0f132d55af7cc78b30658d5b3a4f7be3f449308c8d7fa2ad473677c"
-default['couch_db']['src_version']       = "1.0.2"
-default['couch_db']['src_mirror']        = "http://archive.apache.org/dist/couchdb/#{node['couch_db']['src_version']}/apache-couchdb-#{node['couch_db']['src_version']}.tar.gz"
-default['couch_db']['bind_address']  = nil
+default['couch_db']['src_checksum']   = "6ef82a7ba0f132d55af7cc78b30658d5b3a4f7be3f449308c8d7fa2ad473677c"
+default['couch_db']['src_version']    = "1.0.2"
+default['couch_db']['src_mirror']     = "http://archive.apache.org/dist/couchdb/#{node['couch_db']['src_version']}/apache-couchdb-#{node['couch_db']['src_version']}.tar.gz"
 default['couch_db']['install_erlang'] = true
+
+# Attributes below are used to configure your couchdb instance.
+# These defaults were extracted from this url:
+#  http://wiki.apache.org/couchdb/Configurationfile_couch.ini
+#
+# Configuration file is now removed in favor of dynamic
+# generation.
+
+default['couch_db']['config']['couchdb']['max_document_size'] = 4294967296 # In bytes (4 GB)
+default['couch_db']['config']['couchdb']['max_attachment_chunk_size'] = 4294967296 # In bytes (4 GB)
+default['couch_db']['config']['couchdb']['os_process_timeout'] = 5000 # In ms (5 seconds)
+default['couch_db']['config']['couchdb']['max_dbs_open'] = 100
+default['couch_db']['config']['couchdb']['delayed_commits'] = true
+default['couch_db']['config']['couchdb']['batch_save_size'] = 1000
+default['couch_db']['config']['couchdb']['batch_save_interval'] = 1000  # In ms (1 second)
+
+default['couch_db']['config']['httpd']['port'] = 5984
+default['couch_db']['config']['httpd']['bind_address'] = "127.0.0.1"
+
+default['couch_db']['config']['log']['level'] = "info"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,7 +50,7 @@ template "/etc/couchdb/local.ini" do
   group "couchdb"
   mode 0664
   variables(
-    :bind_address => node['couch_db']['bind_address']
+    :config => node['couch_db']['config']
   )
 end
 

--- a/templates/default/local.ini.erb
+++ b/templates/default/local.ini.erb
@@ -1,49 +1,10 @@
 ; CouchDB Configuration Settings
+; Generated and managed by Chef
 
-; Custom settings should be made in this file. They will override settings
-; in default.ini, but unlike changes made to default.ini, this file won't be
-; overwritten on server upgrade.
-
-[couchdb]
-;max_document_size = 4294967296 ; bytes
-
-[httpd]
-;port = 5984
-<% if @bind_address %>
-bind_address = <%= @bind_address %>
-<% else %>
-;bind_address = 127.0.0.1
+<% @config.each do |section, parameters| %>
+[<%= section %>]
+<% parameters.each do |key, value| %>
+<%= key %> = <%= value %>
 <% end %>
-; Uncomment next line to trigger basic-auth popup on unauthorized requests.
-;WWW-Authenticate = Basic realm="administrator"
 
-[couch_httpd_auth]
-; If you set this to true, you should also uncomment the WWW-Authenticate line
-; above. If you don't configure a WWW-Authenticate header, CouchDB will send
-; Basic realm="server" in order to prevent you getting logged out.
-; require_valid_user = false
-
-[log]
-;level = debug
-
-
-; To enable Virtual Hosts in CouchDB, add a vhost = path directive. All requests to
-; the Virual Host will be redirected to the path. In the example below all requests
-; to http://example.com/ are redirected to /database.
-; If you run CouchDB on a specific port, include the port number in the vhost:
-; example.com:5984 = /database
-
-[vhosts]
-;example.com = /database/
-
-[update_notification]
-;unique notifier name=/full/path/to/exe -with "cmd line arg"
-
-; To create an admin account uncomment the '[admins]' section below and add a
-; line in the format 'username = password'. When you next start CouchDB, it
-; will change the password to a hash (so that your passwords don't linger
-; around in plain-text files). You can add more admin accounts with more
-; 'username = password' lines. Don't forget to restart CouchDB after
-; changing this.
-[admins]
-;admin = mysecretpassword
+<% end %>


### PR DESCRIPTION
Important points of this PR:
- CouchDB's configuration file is now dynamically generated.
- Some sensible defaults are provided for platform-independent parameters.
- Updated README.md with information about configuration settings.

See [COOK-1905](http://tickets.opscode.com/browse/COOK-1905)

Regards,
Matt
