### PR TITLE
Ensure local.ini is loaded after install

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -69,6 +69,11 @@ directory "/var/lib/couchdb" do
   )
 end
 
+# shutdown the couch started by couchdb package
+execute "shutdown-couch" do
+  command "killall couchdb; killall beam; sleep 3"
+end
+
 service "couchdb" do
   if platform_family?("rhel","fedora")
     start_command "/sbin/service couchdb start &> /dev/null"


### PR DESCRIPTION
I'm using the default recipe with Vagrant. It looks like the modified local.ini is not picked up after the package install.
Shutting down couchdb after the install solved the problem for me.
