### PR TITLE
Compilers are needed to build couchdb. 

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,9 +10,10 @@ installed via some other method, either a backported package, or compiled
 directly from source. CouchDB is available on Red Hat-based systems through
 the EPEL Yum Repository.
 EOH
-version           "2.4.1"
+version           "2.4.2"
 depends           "erlang"
 depends           "yum"
+depends           "build-essential"
 recipe            "couchdb", "Installs and configures CouchDB package"
 recipe            "couchdb::source", "Installs and configures CouchDB from source"
 

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -17,6 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe "build-essential"
+
 if node['platform'] == "ubuntu" && node['platform_version'].to_f == 8.04
   log "Ubuntu 8.04 does not supply sufficient development libraries via APT to install CouchDB #{node['couch_db']['src_version']} from source."
   return


### PR DESCRIPTION
You need the gcc/g++ compilers to build couchdb from source. We should add the dependency to 'build-essential'
