### PR TITLE
[COOK-3712] Fixed source recipe execution check

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -73,7 +73,7 @@ bash "install couchdb #{node['couch_db']['src_version']}" do
     tar -zxf #{couchdb_tar_gz}
     cd apache-couchdb-#{node['couch_db']['src_version']} && ./configure #{compile_flags} && make && make install
   EOH
-  not_if { ::FileTest.exists?("/usr/local/bin/couchdb") }
+  not_if "test -f /usr/local/bin/couchdb && /usr/local/bin/couchdb -V | grep 'Apache CouchDB #{node['couch_db']['src_version']}'"
 end
 
 user "couchdb" do


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3712

Added a check on the version so the source recipe can be used to update the CouchDB version on a node.
