### PR TITLE
Add nohup to running couch to make it work with Test Kitchen

### DIFF
--- a/files/default/couchdb.init
+++ b/files/default/couchdb.init
@@ -79,7 +79,7 @@ start_couchdb () {
     mkdir -p "$RUN_DIR"
     if test -n "$COUCHDB_USER"; then
         chown $COUCHDB_USER "$RUN_DIR"
-        if su $COUCHDB_USER -c "$command" > /dev/null; then
+        if nohup su $COUCHDB_USER -c "$command" > /dev/null; then
             return $SCRIPT_OK
         else
             return $SCRIPT_ERROR


### PR DESCRIPTION
Couchdb will immediate stop after a "kitchen converge" due it it being still associated with a tty - adding a nohup will mean it carries on after chef has completed...
