### PR TITLE
Conditionally support upstart

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -71,6 +71,8 @@ service 'couchdb' do
   if platform_family?('rhel', 'fedora')
     start_command '/sbin/service couchdb start &> /dev/null'
     stop_command '/sbin/service couchdb stop &> /dev/null'
+  elsif platform_family?('ubuntu', 'debian')
+    provider Chef::Provider::Service::Upstart
   end
   supports [:restart, :status]
   action [:enable, :start]


### PR DESCRIPTION
This cookbook will fail to start CouchDB and exit out on Ubuntu systems (and I assume debian proxy) as the package installs CouchDB with an Upstart init configuration instead of an init.d script.