### PR TITLE
adding case for libmozjs package for ubuntu 14.04

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -35,6 +35,7 @@ when 'debian'
     'debian' => { 'default' => 'libmozjs-dev' },
     'ubuntu' => {
       '10.04' => 'xulrunner-dev',
+      '14.04' => 'libmozjs185-dev',
       'default' => 'libmozjs-dev'
     }
   )


### PR DESCRIPTION
Ubuntu 14.04 will break since it installs a new version of libmozjs that doesn't work with the couchdb compilation.
