### PR TITLE
Added package gcc-c++ required to build CouchDB 1.6+ on CentOS

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -44,7 +44,7 @@ when 'rhel', 'fedora'
   include_recipe 'yum-epel'
 
   dev_pkgs += %w{
-    which make gcc js-devel libtool
+    which make gcc gcc-c++ js-devel libtool
     libicu-devel openssl-devel curl-devel
   }
 


### PR DESCRIPTION
Patch to fix issue #23. It simply adds package `gcc-c++` when building on `rhel` or `fedora` platforms.
