### PR TITLE
Compiling from source on CentOS 6.5 makes incorrect assumption about library location

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -49,8 +49,12 @@ when 'rhel', 'fedora'
   }
 
   # awkwardly tell ./configure where to find Erlang's headers
-  bitness = node['kernel']['machine'] =~ /64/ ? 'lib64' : 'lib'
-  compile_flags = "--with-erlang=/usr/#{bitness}/erlang/usr/include"
+  # bitness = node['kernel']['machine'] =~ /64/ ? 'lib64' : 'lib'
+  if Dir.exists?("/usr/lib64/erlang/usr/include")
+    compile_flags = "--with-erlang=/usr/lib64/erlang/usr/include"
+  else
+    compile_flags = "--with-erlang=/usr/lib/erlang/usr/include"
+  end
 end
 
 include_recipe 'erlang' if node['couch_db']['install_erlang']

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -49,7 +49,6 @@ when 'rhel', 'fedora'
   }
 
   # awkwardly tell ./configure where to find Erlang's headers
-  # bitness = node['kernel']['machine'] =~ /64/ ? 'lib64' : 'lib'
   if Dir.exists?("/usr/lib64/erlang/usr/include")
     compile_flags = "--with-erlang=/usr/lib64/erlang/usr/include"
   else


### PR DESCRIPTION
Hi, I was just working with this cookbook to install CouchDB on CentOS 6.5 and ran into an issue during the configure / make / make install step.

It's assuming that since the architecture is 64-bit, that the libs reside in `/usr/lib64/erlang/usr/include` even though the erlang RPM is placing them in `/usr/lib/erlang/usr/include`. I've added a `Dir.exists?` test to determine the existing location.

As an aside, it seems that Erlang Solutions has started releasing v. 17 RPMs for CentOS, so relying on using the erlang cookbook will install a version of erlang that cannot build CouchDB. Trying to install an earlier version of the `erlang` package also fails due to some possibly erroneous `obsoletes` settings.

I got around it in my cookbook by instead installing the `esl-erlang` package, which allowed me to complete provisioning using the `couchdb::source` recipe.

```ruby
include_recipe 'yum-erlang_solutions'

package "esl-erlang" do
	version "R16B03-5"
end

include_recipe 'couchdb::source'
```

Thanks!