### PR TITLE
Fixes #20: add an extra file for CouchDB to put uuid into

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,3 +41,5 @@ default['couch_db']['config']['httpd']['port'] = 5984
 default['couch_db']['config']['httpd']['bind_address'] = '127.0.0.1'
 
 default['couch_db']['config']['log']['level'] = 'info'
+
+default['couch_db']['runtime_config_name'] = node['hostname']

--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -1,0 +1,25 @@
+class Chef
+  class Recipe
+    def couchdb_config(base_dir)
+      template File.join(base_dir, 'local.ini') do
+        source 'local.ini.erb'
+        owner 'couchdb'
+        group 'couchdb'
+        mode 0660
+        variables(
+          :config => node['couch_db']['config']
+        )
+        notifies :restart, 'service[couchdb]'
+      end
+
+      # convert to lower case and prepend '~', so it comes last in the config chain
+      runtime_config_name = node['couch_db']['runtime_config_name'].downcase
+      file File.join(base_dir, 'local.d', "~#{runtime_config_name}.ini") do
+        owner 'couchdb'
+        group 'couchdb'
+        mode 0660
+        notifies :restart, 'service[couchdb]'
+      end
+    end
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,16 +44,7 @@ package 'couchdb' do
     )
 end
 
-template '/etc/couchdb/local.ini' do
-  source 'local.ini.erb'
-  owner 'couchdb'
-  group 'couchdb'
-  mode 0664
-  variables(
-    :config => node['couch_db']['config']
-  )
-  notifies :restart, 'service[couchdb]'
-end
+couchdb_config '/etc/couchdb'
 
 directory '/var/lib/couchdb' do
   owner 'couchdb'

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -88,16 +88,7 @@ end
   end
 end
 
-template '/usr/local/etc/couchdb/local.ini' do
-  source 'local.ini.erb'
-  owner 'couchdb'
-  group 'couchdb'
-  mode 0660
-  variables(
-    :config => node['couch_db']['config']
-  )
-  notifies :restart, 'service[couchdb]'
-end
+couchdb_config '/usr/local/etc/couchdb'
 
 cookbook_file '/etc/init.d/couchdb' do
   source 'couchdb.init'


### PR DESCRIPTION
CouchDB will put the `uuid` into the 'last file in the configuration
chain' (see: https://issues.apache.org/jira/browse/COUCHDB-2064). Added
a file that will be last lexicographically (with name in upper case), so
the file managed by Chef won't be touched on every restart.