### PR TITLE
LWRP for creating CouchDB admins

### DIFF
--- a/providers/admin.rb
+++ b/providers/admin.rb
@@ -1,0 +1,45 @@
+require 'openssl'
+
+def whyrun_supported?
+  true
+end
+
+action :create do
+  raise 'Password is required for :create action' unless new_resource.password
+
+  template get_config_filename do
+    source 'admin.erb'
+    cookbook 'couchdb'
+    owner 'couchdb'
+    group 'couchdb'
+    mode 0664
+    variables :login => new_resource.login,
+              :hash => generate_hash
+  end
+end
+
+action :delete do
+  file get_config_filename do
+    action :delete
+  end
+end
+
+def get_config_filename
+  if node['couch_db'].attribute?('config_dir')
+    ::File.join(node['couch_db']['config_dir'], 'local.d', "_admin_#{new_resource.login}.ini")
+  else
+    raise 'Config directory not found. ' +
+     'Be sure to run `default` or `source` recipe prior to using couchdb_admin resource'
+  end
+end
+
+# Generates hash of the password using PBKDF2 algorithm, so it can be used by CouchDB
+def generate_hash
+  salt = OpenSSL::Random.random_bytes(new_resource.salt_length).unpack('H*')[0]
+  iterations = new_resource.iterations
+  hash = OpenSSL::PKCS5.pbkdf2_hmac_sha1(new_resource.password,
+                                         salt,
+                                         iterations, 
+                                         new_resource.key_length).unpack('H*')[0]
+  "-pbkdf2-#{hash},#{salt},#{iterations}"
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,7 +44,9 @@ package 'couchdb' do
     )
 end
 
-template '/etc/couchdb/local.ini' do
+node.set['couch_db']['config_dir'] = config_dir = '/etc/couchdb'
+
+template File.join(config_dir, 'local.ini') do
   source 'local.ini.erb'
   owner 'couchdb'
   group 'couchdb'

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -88,7 +88,9 @@ end
   end
 end
 
-template '/usr/local/etc/couchdb/local.ini' do
+node.set['couch_db']['config_dir'] = config_dir = '/usr/local/etc/couchdb'
+
+template File.join(config_dir, 'local.ini') do
   source 'local.ini.erb'
   owner 'couchdb'
   group 'couchdb'

--- a/resources/admin.rb
+++ b/resources/admin.rb
@@ -1,0 +1,14 @@
+#
+# Cookbook Name:: couchdb
+# Resource:: admin
+#
+# Author:: Artur Nowak (<artur.nowak@evidenceprime.com>)
+
+actions :create, :delete
+default_action :create
+
+attribute :login, :kind_of       => String, :name_attribute => true, :required => true
+attribute :password, :kind_of    => String
+attribute :salt_length, :kind_of => Fixnum, :default  => 16
+attribute :iterations, :kind_of  => Fixnum, :default  => 10
+attribute :key_length, :kind_of  => Fixnum, :default  => 20

--- a/templates/default/admin.erb
+++ b/templates/default/admin.erb
@@ -1,0 +1,5 @@
+; CouchDB Admin entry
+; Generated and managed by Chef
+
+[admins]
+<%= @login %> = <%= @hash %>


### PR DESCRIPTION
Creation of admin users via the main config file
(i.e. setting `node['couch_db']['config']['admins'][login]`) is
problematic, because after CouchDB hashes the plain text passwords on
start, the file is seen as modified by CouchDB. This in turn causes
unnecessary server restarts on every Chef run.

Using hack similar to https://github.com/wohali/couchdb-cookbook/pull/28
makes CouchDB append the hashes to the 'last file in the config chain',
which means that the Chef-generated file is untouched, but on the other
hand all the passwords are left in clear text.

This LWRP adds separate `local.d` config file for every administrator,
hashing the passwords the same way as CouchDB would, so user creation
finally becomes idempotent.

Example usage:

```
couchdb_admin 'alice' do
  password 'secret' # preferably, taken from an encrypted databag
  iterations 1000 # 10 is default
end
```
