### PR TITLE
Fix Installation in Debian Wheezy

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -32,7 +32,10 @@ when 'debian'
   dev_pkgs << 'libicu-dev'
   dev_pkgs << 'libcurl4-openssl-dev'
   dev_pkgs << value_for_platform(
-    'debian' => { 'default' => 'libmozjs-dev' },
+    'debian' => { 
+      '~> 7.0' => 'libmozjs185-dev',
+      'default' => 'libmozjs-dev'
+    },
     'ubuntu' => {
       '10.04' => 'xulrunner-dev',
       '14.04' => 'libmozjs185-dev',


### PR DESCRIPTION
Debian Wheezy requires libmozjs185-dev to install CouchDB from Source