### PR TITLE
Adding database LWRP to the cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ source
 
 Downloads the CouchDB source from the Apache project site, plus development dependencies. Then builds the binaries for installation, creates a user and directories, then sets up the couchdb service. Uses the init script provided in the cookbook.
 
+LWRPs
+=====
+
+database
+--------
+Can be used to create a database on a CouchDB install.
+
+* `database_name` - name of the database to create.
+* `database_host` - host name or IP address of the database server.
+* `database_port` - TCP port of the database server.
+* `couchdb_user` - username to bind to the CouchDB server with (optional).
+* `couchdb_password` - password to bind to the CouchDB server with (optional).
+
+
 License and Author
 ==================
 

--- a/providers/database.rb
+++ b/providers/database.rb
@@ -1,0 +1,62 @@
+
+require 'chef/mixin/shell_out'
+require 'chef/mixin/language'
+require 'json'
+
+def whyrun_supported?
+  true
+end
+
+action :create do
+  if @current_resource.exists
+    Chef::Log.info "#{ @new_resource } already exists - nothing to do."
+  else
+    converge_by("Create #{ @new_resource }") do
+      create_database
+    end
+  end
+end
+
+action :delete do
+  if @current_resource.exists
+    converge_by("Delete #{ @new_resource }") do
+      delete_database
+    end
+  else
+    Chef::Log.info "#{ @current_resource } doesn't exist - can't delete."
+  end
+end
+
+def load_current_resource
+
+  @current_resource = Chef::Resource::CouchdbDatabase.new(@new_resource.name)
+  @current_resource.name(@new_resource.name)
+  @current_resource.couchdb_user(@new_resource.couchdb_user)
+  @current_resource.couchdb_password(@new_resource.couchdb_password)
+
+  if database_exists?(@current_resource.database_name)
+    @current_resource.exists = true
+  end
+end
+
+def create_database
+  cmd = Mixlib::ShellOut.new(create_db_command)
+  cmd.run_command
+  response = JSON.parse(cmd.stdout)
+  Chef::Application.fatal!("Unable to create DB!") unless response.include?("ok")
+end
+
+def create_db_command
+  if new_resource.couchdb_user == nil && new_resource.couchdb_password == nil
+    "curl -X PUT http://#{new_resource.database_host}:#{new_resource.database_port}/#{new_resource.database_name}"
+  else
+    "curl -X PUT http://#{new_resource.couchdb_user}:#{new_resource.couchdb_password}@#{new_resource.database_host}:#{new_resource.database_port}/#{new_resource.database_name}"
+  end
+end
+
+def database_exists?(name)
+  Chef::Log.debug "Checking to see if the #{new_resource.database_name} database exists."
+  result = JSON.parse(`curl -X GET http://#{new_resource.database_host}:#{new_resource.database_port}/_all_dbs`)
+  result.include?(new_resource.database_name)
+end
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,8 @@
 
 include_recipe 'erlang' if node['couch_db']['install_erlang']
 
+package "curl"
+
 case node['platform_family']
 when 'rhel'
   group 'couchdb' do
@@ -76,3 +78,4 @@ service 'couchdb' do
   supports [:restart, :status]
   action [:enable, :start]
 end
+

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -17,6 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+package "curl"
+
 if node['platform'] == 'ubuntu' && node['platform_version'].to_f == 8.04
   log "Ubuntu 8.04 does not supply sufficient development libraries via APT to install CouchDB #{node['couch_db']['src_version']} from source."
   return

--- a/resources/database.rb
+++ b/resources/database.rb
@@ -1,0 +1,12 @@
+
+actions :create, :delete
+default_action :create
+
+attribute :database_name, :name_attribute => true, :kind_of => String, :required => true
+attribute :database_host, :kind_of => String, :default => node['couch_db']['config']['httpd']['bind_address']
+attribute :database_port, :kind_of => Fixnum, :default => node['couch_db']['config']['httpd']['port']
+attribute :couchdb_user, :kind_of => String, :default => nil
+attribute :couchdb_password, :kind_of => String, :default => nil
+
+attr_accessor :exists
+


### PR DESCRIPTION
Used to manage the creation and (eventually) deletion of CouchDB databases (squashed version of #34 ).
- Adding curl install to recipes - needed for LWRP.
- Added user and password attributes to the database LWRP in case admin party is disabled.
- Updated load_current_resource method to include new user and password attributes.
- Removed call to database LWRP from default recipe - inadvertantly committed.
- Moved create database commands to distinct method, using this to populate a shellout request from which a JSON response is parsed.
- Removed erroneous "code" keyword prefacing the db creation command strings.
- Corrected invalid call to shell_out.
- Tried alternative means of calling shellout.
- Fixed incorrect call to include? method.
- Log fatal error if unable to create DB.
- Changed Chef::Log.fatal to Chef::Application.fatal! - ensuring the Chef run is aborted.
- Updated the README to document the database LWRP.
