### PR TITLE
Fix mozillajs dev package for debian 8

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -32,8 +32,8 @@ when 'debian'
   dev_pkgs << 'libicu-dev'
   dev_pkgs << 'libcurl4-openssl-dev'
   dev_pkgs << value_for_platform(
-    'debian' => { 
-      '~> 7.0' => 'libmozjs185-dev',
+    'debian' => {
+      ['~> 7.0', '< 9.0'] => 'libmozjs185-dev',
       'default' => 'libmozjs-dev'
     },
     'ubuntu' => {


### PR DESCRIPTION
Since `couchdb` package is not available on debian 8, we need to install
it from source with `couchdb::source`. This patch install same dev
packages for debian 7 & 8 (libmozjs185-dev).
